### PR TITLE
Bugfixes

### DIFF
--- a/openclio/openclio.py
+++ b/openclio/openclio.py
@@ -437,11 +437,10 @@ def getHierarchy(
                     clusterNames = extractAnswerNumberedList(clusterNamesOutput, ignoreNoTrailing=True)
                     if len(clusterNames) != 0:
                         cfg.print("Success at manual retry")
-                        break
+                        return [(removePunctuation(clusterName).strip(), clusterIndicesInNeighborhood) for clusterName in clusterNames]
                     else:
                         cfg.print("Failed manual retry, trying again")
-                        cfg.print(output)
-                    return [(removePunctuation(clusterName).strip(), clusterIndicesInNeighborhood) for clusterName in clusterNames[:desired]]
+                        cfg.print(clusterNamesOutput)
             
             def dedupAndMergeSources(values: List[Tuple[str, Sources]]) -> List[Tuple[str, Sources]]:
                 resultValues = defaultdict(lambda: set())
@@ -494,7 +493,7 @@ def getHierarchy(
                 # fall back to dedup based on embedding (usually this means model got stuck in a loop, and it's better we ignore its outputs)
                 if len(extractedOptions) == 0:
                     # no dedup extracted, falling back to dedup based on embedding 
-                    extractedOptions = deduplicateByEmbeddingsAndMergeSources(valuesAndSources=higherCategoriesInNeighborhood, embeddingModel=embeddingModel, tau=0.1)
+                    extractedOptions = [value for value, _ in deduplicateByEmbeddingsAndMergeSources(valuesAndSources=higherCategoriesInNeighborhood, embeddingModel=embeddingModel, tau=0.1)]
                 return [(removePunctuation(output).strip(), allSources) for output in extractedOptions]
 
 


### PR DESCRIPTION
Fixes a few bugs in the error handling/fallback code in `getHierarchy.processOutputFunc`:
1. Previously, the `break` statement on line 440 was causing the function to break out of the while loop and not return anything, causing downstream errors. I fixed this by causing it to actually return the manual retry result. I also fixed an error where if the manual retry failed, `cfg.print(output)` would run, but the `output` variable is not defined.
2. Previously, the fallback dedup method on line 496 was getting an array of tuples of (value, source), but then expecting it to be an array of strings (calling `strip` on each entry), leading to errors. I fixed this by taking only the first entry (the value) from each element in the array.